### PR TITLE
Update dicio-cli

### DIFF
--- a/dicio-cli
+++ b/dicio-cli
@@ -13,7 +13,7 @@ get_accented_word() {
 }
 
 get_word_definition() {
-  DOM_WORD_DEFINITION='<p itemprop="description" class="significado textonovo">'
+  DOM_WORD_DEFINITION='<p class="significado textonovo">'
   WORD_DEFINITION=$(curl -s "https://www.dicio.com.br/${WORD_TO_SEARCH}/" | grep "${DOM_WORD_DEFINITION}")
 }
 
@@ -22,8 +22,8 @@ remove_paragraph() {
 }
 
 stylize_tags() {
+  WORD_DEFINITION=$(echo ${WORD_DEFINITION} | sed s/'<span class="cl">'/" \\${COLORS[MAGENTA]}"/g | sed s/']<\/span>'/"]\\${COLORS[WHITE]}"/g)
   WORD_DEFINITION=$(echo ${WORD_DEFINITION} | sed s/'<span class="tag">'/" \\${COLORS[YELLOW]}"/g | sed s/']<\/span>'/"]\\${COLORS[WHITE]}"/g)
-  WORD_DEFINITION="$(echo ${WORD_DEFINITION} | sed s/'<span class="cl">'/"\\${COLORS[MAGENTA]}|"/g | sed s/'<\/span>'/\\"${COLORS[WHITE]} |"/g | awk -F'[|]' '{ print $0}')"
   WORD_DEFINITION=$(echo ${WORD_DEFINITION} | sed s/'<span class="etim">'/\\${COLORS[GRAY]}/g | sed s/'<i>'//g | sed s/'<\/i>).'/").\\${COLORS[WHITE]}"/g)
 }
 


### PR DESCRIPTION
Fiz uma melhoria no código. 
---
Na função get_word_definition(), o valor da variável DOM_WORD_DEFINITION foi alterado para corresponder à nova tag HTML:

```bash
DOM_WORD_DEFINITION='<p class="significado textonovo">'
WORD_DEFINITION=$(curl -s "https://www.dicio.com.br/${WORD_TO_SEARCH}/" | grep "${DOM_WORD_DEFINITION}")
```
Na função stylize_tags(), houve alterações para manipular as novas tags HTML conforme a estrutura fornecida:

```bash
stylize_tags() {
  WORD_DEFINITION=$(echo ${WORD_DEFINITION} | sed s/'<span class="cl">'/" \\${COLORS[MAGENTA]}"/g | sed s/']<\/span>'/"]\\${COLORS[WHITE]}"/g)
  WORD_DEFINITION=$(echo ${WORD_DEFINITION} | sed s/'<span class="tag">'/" \\${COLORS[YELLOW]}"/g | sed s/']<\/span>'/"]\\${COLORS[WHITE]}"/g)
  WORD_DEFINITION=$(echo ${WORD_DEFINITION} | sed s/'<span class="etim">'/\\${COLORS[GRAY]}/g | sed s/'<i>'//g | sed s/'<\/i>).'/").\\${COLORS[WHITE]}"/g)
}
```
Na função remove_paragraph(), houve alterações para substituir a tag HTML <p class="significado textonovo"> pela vazia, removendo-a do texto:
```bash
remove_paragraph() {
  WORD_DEFINITION=$(echo ${WORD_DEFINITION} | sed s/"${DOM_WORD_DEFINITION}"//g | sed s/'<\/p>'//g | sed s/'<br \/>'//g)
}
```
Resultando em uma nova gama de informações pelo CLI:
---
![Captura de tela de 2024-05-24 10-48-26](https://github.com/ludovici-philippus/dicio-cli/assets/72875404/d5b1f181-04e2-42d9-9051-3bbea91e0f49)