### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Este script faz um web scraping no site: https://www.dicio.com.br/ e formata o r
 ## Instalação
 A instalação desse script pode ser feita por meio dos seguintes comandos:
 
-- git clone "https://github.com/ludovici-philippus/dicio-cli"
+- git clone https://github.com/ludovici-philippus/dicio-cli
 - cd dicio-cli && sudo mv dicio-cli /usr/local/bin
+- chmod +x dicio-cli
+
 
 Depois disso basta partir para o uso!
 


### PR DESCRIPTION
Não há mais aspas para se usar com `git clone ""`.
`dicio-cli` é um arquivo shell, portanto deve ter o comando `chmod +x` para usuário saber que terá que dá permissão de execução.